### PR TITLE
Correct ERC-4626 compliance claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,10 @@ Spark Vaults V2 is a fork of sUSDS, sharing much of the same functionality. The 
 
 ## Features
 
-- **ERC4626 Compliance**: Full implementation of the ERC4626 vault standard.
+- **ERC4626 Compliance**: Implements the ERC4626 vault interface with two documented divergences reviewed by Cantina + ChainSecurity:
+  - `previewRedeem` / `previewWithdraw` revert on insufficient liquidity, interpreted under the EIP clause *"MAY revert due to other conditions that would also cause redeem to revert."*
+  - `maxMint` returns `type(uint256).max` when `depositCap > type(uint256).max / RAY`, following the "no-limit sentinel" reading shared by OpenZeppelin and Solmate.
+  - The underlying asset is assumed non-rebasing, non-fee-on-transfer, and non-reentrant (see [`TECHNICAL.md`](./TECHNICAL.md) / audit reports).
 - **Continuous Rate Accumulation**: Automatic yield distribution through per-second rate accumulation based on a set rate (`vsr`).
 - **Referral System**: Built-in referral tracking.
 - **Upgradeable**: UUPS upgradeable contract architecture.


### PR DESCRIPTION
## Summary

  Replaces *"Full implementation of the ERC4626 vault standard"* with a
  precise statement that surfaces the two documented spec divergences
  already accepted by Cantina + ChainSecurity, plus the asset trust
  assumptions that live in `TECHNICAL.md`.

  ## Why

  The current line is stronger than the actual conformance:

  - `previewRedeem` / `previewWithdraw` revert on insufficient liquidity
    (Cantina v1.0.1 S3.1.2 Acknowledged; ChainSecurity S8.4 Note).
  - `maxMint` returns `type(uint256).max` when
    `depositCap > type(uint256).max / RAY` (ChainSecurity S8.6 Note;
    team test `test_maxMint_extremelyLargeDepositCap` asserts intent).
  - ChainSecurity v1.0.1 S2.3 trust model assumes the asset is
    non-rebasing / non-fee-on-transfer / non-reentrant.

  Integrators reading only the README would miss all three. Making the
  divergences explicit (and pointing to `TECHNICAL.md` + audits) lets
  integrators decide ahead of time whether the vault matches their
  expectations.

  ## Changes

  - `README.md`: replace one bullet with a qualified bullet + 3 nested
    divergence/assumption sub-bullets. No code changes.
